### PR TITLE
Add compatibility with newer guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,12 @@
 
   "require": {
     "php": ">=5.3.0",
-    "guzzle/guzzle": "3.8.*"
+    "guzzle/guzzle": "~3.8"
   },
 
   "require-dev": {
     "phpunit/phpunit": "*",
-    "slim/slim": "dev-develop"
+    "slim/slim": "*"
   },
 
   "autoload": {


### PR DESCRIPTION
Library is compatible with guzzle 3.9.\* as well. So there is no reason to restrict to 3.8
